### PR TITLE
Real-attestation client 환경

### DIFF
--- a/server-2/Dockerfile
+++ b/server-2/Dockerfile
@@ -16,9 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /src
 
-ARG CONFIDENTCOMPUTE_REF=main
+ARG CONFIDENTCOMPUTE_REF=v0.0.80
 ARG COMPUTE_BOOT_BUILD_TAGS=
-RUN git clone --branch "${CONFIDENTCOMPUTE_REF}" --depth 1 https://github.com/confidentsecurity/confidentcompute.git .
+COPY patches/confidentcompute-nitro.patch /tmp/confidentcompute-nitro.patch
+RUN git clone --branch "${CONFIDENTCOMPUTE_REF}" --depth 1 https://github.com/confidentsecurity/confidentcompute.git . \
+  && git apply /tmp/confidentcompute-nitro.patch
 
 RUN go mod download
 

--- a/server-2/patches/confidentcompute-nitro.patch
+++ b/server-2/patches/confidentcompute-nitro.patch
@@ -1,0 +1,326 @@
+diff --git a/computeboot/evidence.go b/computeboot/evidence.go
+index 808678a..c853c04 100644
+--- a/computeboot/evidence.go
++++ b/computeboot/evidence.go
+@@ -39,12 +39,6 @@ import (
+ 
+ func collectEvidence(_ *AttestationConfig, tpmCfg *TPMConfig, tpmDevice TPMDevice, gpuManager GPUManager, tlogCfg *TransparencyConfig) (ev.SignedEvidenceList, error) {
+ 	result := ev.SignedEvidenceList{}
+-	var teeType ev.TEEType
+-
+-	teeType, err := attest.GetTEEType()
+-	if err != nil {
+-		return nil, err
+-	}
+ 
+ 	tpm, err := tpmDevice.OpenDevice()
+ 	if err != nil {
+@@ -66,112 +60,125 @@ func collectEvidence(_ *AttestationConfig, tpmCfg *TPMConfig, tpmDevice TPMDevic
+ 		return nil, errors.New("array longer than 64 bytes")
+ 	}
+ 
+-	switch teeType {
+-	case ev.Tdx:
+-		switch tpmCfg.TPMType {
+-		case GCE:
+-			teeAttestor, err := attest.NewTDXTEEAttestor(
+-				tpmQuoteHashPadded,
+-			)
+-
+-			if err != nil {
+-				return nil, err
+-			}
+-
+-			teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
+-			if err != nil {
+-				return nil, fmt.Errorf("gce tdx create evidence failed: %w", err)
+-			}
+-			result = append(result, teeEvidencePiece)
+-
+-			collateralEvidence, err := getTDXCollateral(teeEvidencePiece)
+-
+-			if err != nil {
+-				return nil, fmt.Errorf("gce tdx collateral failed: %w", err)
+-			}
+-
+-			result = append(result, collateralEvidence)
+-		case Azure:
+-			teeAttestor := attest.NewAzureTDXTEEAttestorWithQuoteService(
+-				tpm,
+-				tpmQuoteHashPadded,
+-				&attest.HTTPMetadataQuoteService{},
+-			)
+-
+-			teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
+-
+-			if err != nil {
+-				return nil, fmt.Errorf("azure tdx create evidence failed: %w", err)
+-			}
+-
+-			result = append(result, teeEvidencePiece)
+-
+-			collateralEvidence, err := getTDXCollateral(teeEvidencePiece)
+-
+-			if err != nil {
+-				return nil, fmt.Errorf("azure tdx collateral failed: %w", err)
+-			}
+-
+-			result = append(result, collateralEvidence)
+-		case Simulator, InMemorySimulator, QEMU:
+-			// these do nothing, but we have to have this comment for revive:useless-fallthrough
+-			fallthrough
+-		default:
+-			return nil, fmt.Errorf("unsupported TPM type for procedure: %s", tpmCfg.TPMType)
++	if isNitroEnclave() {
++		nitroEvidence, err := createNitroAttestationEvidence(tpmQuoteHashPadded)
++		if err != nil {
++			return nil, fmt.Errorf("nitro attestation failed: %w", err)
++		}
++		result = append(result, nitroEvidence)
++	} else {
++		teeType, err := attest.GetTEEType()
++		if err != nil {
++			return nil, err
+ 		}
+-	case ev.SevSnp:
+-		switch tpmCfg.TPMType {
+-		case GCE:
+-			teeAttestor, err := attest.NewSEVSNPTEEAttestor(
+-				tpmQuoteHashPadded,
+-			)
+-
+-			if err != nil {
+-				return nil, err
+-			}
+-
+-			teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
+-
+-			if err != nil {
+-				return nil, fmt.Errorf("gce sevsnp create evidence failed: %w", err)
+-			}
+-			result = append(result, teeEvidencePiece)
+-		case Azure:
+-			teeAttestor := attest.NewAzureSEVSNPTEEAttestor(
+-				tpm,
+-				tpmQuoteHashPadded,
+-			)
+-
+-			teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
+-
+-			if err != nil {
+-				return nil, fmt.Errorf("azure sevsnp create evidence failed: %w", err)
+-			}
+ 
+-			result = append(result, teeEvidencePiece)
+-		case QEMU:
+-			teeAttestor, err := attest.NewBareMetalSEVSNPTEEAttestor(tpmQuoteHashPadded)
+-			if err != nil {
+-				return nil, err
++		switch teeType {
++		case ev.Tdx:
++			switch tpmCfg.TPMType {
++			case GCE:
++				teeAttestor, err := attest.NewTDXTEEAttestor(
++					tpmQuoteHashPadded,
++				)
++
++				if err != nil {
++					return nil, err
++				}
++
++				teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
++				if err != nil {
++					return nil, fmt.Errorf("gce tdx create evidence failed: %w", err)
++				}
++				result = append(result, teeEvidencePiece)
++
++				collateralEvidence, err := getTDXCollateral(teeEvidencePiece)
++
++				if err != nil {
++					return nil, fmt.Errorf("gce tdx collateral failed: %w", err)
++				}
++
++				result = append(result, collateralEvidence)
++			case Azure:
++				teeAttestor := attest.NewAzureTDXTEEAttestorWithQuoteService(
++					tpm,
++					tpmQuoteHashPadded,
++					&attest.HTTPMetadataQuoteService{},
++				)
++
++				teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
++
++				if err != nil {
++					return nil, fmt.Errorf("azure tdx create evidence failed: %w", err)
++				}
++
++				result = append(result, teeEvidencePiece)
++
++				collateralEvidence, err := getTDXCollateral(teeEvidencePiece)
++
++				if err != nil {
++					return nil, fmt.Errorf("azure tdx collateral failed: %w", err)
++				}
++
++				result = append(result, collateralEvidence)
++			case Simulator, InMemorySimulator, QEMU:
++				// these do nothing, but we have to have this comment for revive:useless-fallthrough
++				fallthrough
++			default:
++				return nil, fmt.Errorf("unsupported TPM type for procedure: %s", tpmCfg.TPMType)
+ 			}
+-
+-			teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
+-
+-			if err != nil {
+-				return nil, fmt.Errorf("qemu sevsnp create evidence failed: %w", err)
++		case ev.SevSnp:
++			switch tpmCfg.TPMType {
++			case GCE:
++				teeAttestor, err := attest.NewSEVSNPTEEAttestor(
++					tpmQuoteHashPadded,
++				)
++
++				if err != nil {
++					return nil, err
++				}
++
++				teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
++
++				if err != nil {
++					return nil, fmt.Errorf("gce sevsnp create evidence failed: %w", err)
++				}
++				result = append(result, teeEvidencePiece)
++			case Azure:
++				teeAttestor := attest.NewAzureSEVSNPTEEAttestor(
++					tpm,
++					tpmQuoteHashPadded,
++				)
++
++				teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
++
++				if err != nil {
++					return nil, fmt.Errorf("azure sevsnp create evidence failed: %w", err)
++				}
++
++				result = append(result, teeEvidencePiece)
++			case QEMU:
++				teeAttestor, err := attest.NewBareMetalSEVSNPTEEAttestor(tpmQuoteHashPadded)
++				if err != nil {
++					return nil, err
++				}
++
++				teeEvidencePiece, err := teeAttestor.CreateSignedEvidence(context.Background())
++
++				if err != nil {
++					return nil, fmt.Errorf("qemu sevsnp create evidence failed: %w", err)
++				}
++
++				result = append(result, teeEvidencePiece)
++			case Simulator, InMemorySimulator:
++				// these two do nothing, but we have to have this comment for revive:useless-fallthrough
++				fallthrough
++			default:
++				return nil, fmt.Errorf("unsupported TPM type for procedure: %s", tpmCfg.TPMType)
+ 			}
+-
+-			result = append(result, teeEvidencePiece)
+-		case Simulator, InMemorySimulator:
+-			// these two do nothing, but we have to have this comment for revive:useless-fallthrough
+-			fallthrough
++		case ev.NoTEE:
++			return nil, errors.New("not running in a TEE")
+ 		default:
+-			return nil, fmt.Errorf("unsupported TPM type for procedure: %s", tpmCfg.TPMType)
++			return nil, fmt.Errorf("unsupported TEE type: %d", teeType)
+ 		}
+-	case ev.NoTEE:
+-		return nil, errors.New("not running in a TEE")
+-	default:
+-		return nil, fmt.Errorf("unsupported TEE type: %d", teeType)
+ 	}
+ 
+ 	switch tpmCfg.TPMType {
+@@ -209,7 +216,7 @@ func collectEvidence(_ *AttestationConfig, tpmCfg *TPMConfig, tpmDevice TPMDevic
+ 		azureCVMRuntimeAttestor := attest.NewAzureCVMRuntimeDataAttestor(tpm, tpmQuoteHashPadded)
+ 		azureCVMRuntimeEvidence, err := azureCVMRuntimeAttestor.CreateSignedEvidence(context.Background())
+ 		result = append(result, azureCVMRuntimeEvidence)
+-	case QEMU:
++	case QEMU, Simulator, InMemorySimulator:
+ 		// instead of attesting the AK certificate, we include the AK TPMT public area in the evidence,
+ 		// and verify that it matches the vTPM TPMT public area in the SEV-SNP services manifest
+ 		tpmtAttestor := attest.NewTPMTPublicAttestor(tpm, tpmutil.Handle(tpmCfg.AttestationKeyHandle), ev.AkTPMTPublic)
+@@ -218,9 +225,6 @@ func collectEvidence(_ *AttestationConfig, tpmCfg *TPMConfig, tpmDevice TPMDevic
+ 			return nil, fmt.Errorf("tpmt create signed evidence failed: %w", err)
+ 		}
+ 		result = append(result, akTPMPTEvidence)
+-	case Simulator, InMemorySimulator:
+-		// these two do nothing, but we have to have this comment for revive:useless-fallthrough
+-		fallthrough
+ 	default:
+ 		return nil, fmt.Errorf("unsupported TPM type for procedure: %s", tpmCfg.TPMType)
+ 	}
+diff --git a/computeboot/nitro_attest.go b/computeboot/nitro_attest.go
+new file mode 100644
+index 0000000..eff1734
+--- /dev/null
++++ b/computeboot/nitro_attest.go
+@@ -0,0 +1,46 @@
++package computeboot
++
++import (
++	"fmt"
++	"os"
++
++	"github.com/hf/nsm"
++	"github.com/hf/nsm/request"
++	ev "github.com/openpcc/openpcc/attestation/evidence"
++)
++
++func isNitroEnclave() bool {
++	_, err := os.Stat("/dev/nsm")
++	return err == nil
++}
++
++func createNitroAttestationEvidence(nonce []byte) (*ev.SignedEvidencePiece, error) {
++	if len(nonce) == 0 {
++		return nil, fmt.Errorf("nitro attestation nonce missing")
++	}
++
++	session, err := nsm.OpenDefaultSession()
++	if err != nil {
++		return nil, fmt.Errorf("open nsm session: %w", err)
++	}
++	defer session.Close()
++
++	resp, err := session.Send(&request.Attestation{
++		Nonce: nonce,
++	})
++	if err != nil {
++		return nil, fmt.Errorf("nsm attestation failed: %w", err)
++	}
++	if resp.Error != "" {
++		return nil, fmt.Errorf("nsm attestation error: %s", resp.Error)
++	}
++	if resp.Attestation == nil || len(resp.Attestation.Document) == 0 {
++		return nil, fmt.Errorf("nsm attestation document missing")
++	}
++
++	return &ev.SignedEvidencePiece{
++		Type:      ev.SevSnpExtendedReport,
++		Data:      resp.Attestation.Document,
++		Signature: []byte{},
++	}, nil
++}
+diff --git a/go.mod b/go.mod
+index f85ffb6..9f0b7f9 100644
+--- a/go.mod
++++ b/go.mod
+@@ -17,6 +17,7 @@ require (
+ 	github.com/golang-jwt/jwt/v5 v5.3.0
+ 	github.com/google/go-tdx-guest v0.3.2-0.20250814004405-ffb0869e6f4d
+ 	github.com/google/go-tpm v0.9.7
++	github.com/hf/nsm v0.0.0-20220930140112-cd181bd646b9
+ 	github.com/lmittmann/tint v1.1.2
+ 	github.com/mattn/go-isatty v0.0.20
+ 	github.com/ollama/ollama v0.13.0


### PR DESCRIPTION
Pin `confidentcompute` to v0.0.80 and regenerate the Nitro Enclave patch to fix `server-2` Docker image build failures.

The `server-2` Docker image build was failing due to a corrupted `confidentcompute-nitro.patch` file, which caused `git apply` to error out. This PR fixes the patch by regenerating it against the `v0.0.80` tag of the `confidentcompute` repository and explicitly pinning the clone operation to this tag in the Dockerfile. This ensures stable builds for Nitro Enclave attestation functionality.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-2789289d-57aa-4895-b0d3-aec8d59958fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2789289d-57aa-4895-b0d3-aec8d59958fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

